### PR TITLE
Adding postStart to Lifecycle, using default interface

### DIFF
--- a/service-framework-core/src/main/java/com/daedafusion/sf/AbstractManagedObject.java
+++ b/service-framework-core/src/main/java/com/daedafusion/sf/AbstractManagedObject.java
@@ -165,28 +165,25 @@ public abstract class AbstractManagedObject implements ManagedObject
     @Override
     public void start()
     {
-        for(LifecycleListener listener : listeners)
-        {
-            listener.start();
-        }
+        listeners.forEach(LifecycleListener::start);
+    }
+
+    @Override
+    public void postStart()
+    {
+        listeners.forEach(LifecycleListener::postStart);
     }
 
     @Override
     public void stop()
     {
-        for(LifecycleListener listener : listeners)
-        {
-            listener.stop();
-        }
+        listeners.forEach(LifecycleListener::stop);
     }
 
     @Override
     public void teardown()
     {
-        for(LifecycleListener listener : listeners)
-        {
-            listener.teardown();
-        }
+        listeners.forEach(LifecycleListener::teardown);
     }
 
     public List<LifecycleListener> getListeners()

--- a/service-framework-core/src/main/java/com/daedafusion/sf/LifecycleListener.java
+++ b/service-framework-core/src/main/java/com/daedafusion/sf/LifecycleListener.java
@@ -5,8 +5,9 @@ package com.daedafusion.sf;
  */
 public interface LifecycleListener
 {
-    void init();
-    void start();
-    void stop();
-    void teardown();
+    default void init(){}
+    default void start(){}
+    default void postStart(){}
+    default void stop(){}
+    default void teardown(){}
 }

--- a/service-framework-core/src/main/java/com/daedafusion/sf/ServiceFramework.java
+++ b/service-framework-core/src/main/java/com/daedafusion/sf/ServiceFramework.java
@@ -27,20 +27,16 @@ public final class ServiceFramework
             throw new ServiceFrameworkException("Framework did not initialize");
         }
 
-        for(ManagedObject mo : serviceRegistry.getManagedObjects())
-        {
-            mo.start();
-        }
+        serviceRegistry.getManagedObjects().forEach(LifecycleListener::start);
 
         isStarted = true;
+
+        serviceRegistry.getManagedObjects().forEach(LifecycleListener::postStart);
     }
 
     public void stop()
     {
-        for(ManagedObject mo : serviceRegistry.getManagedObjects())
-        {
-            mo.stop();
-        }
+        serviceRegistry.getManagedObjects().forEach(LifecycleListener::stop);
 
         isStarted = false;
     }
@@ -55,10 +51,7 @@ public final class ServiceFramework
             stop();
         }
 
-        for(ManagedObject mo : serviceRegistry.getManagedObjects())
-        {
-            mo.teardown();
-        }
+        serviceRegistry.getManagedObjects().forEach(LifecycleListener::teardown);
     }
 
     public <T> T getService(Class<T> inf)

--- a/service-framework-core/src/main/java/com/daedafusion/sf/impl/BackgroundServiceImpl.java
+++ b/service-framework-core/src/main/java/com/daedafusion/sf/impl/BackgroundServiceImpl.java
@@ -18,29 +18,11 @@ public class BackgroundServiceImpl extends AbstractService<BackgroundServiceProv
         addLifecycleListener(new LifecycleListener()
         {
             @Override
-            public void init()
-            {
-
-            }
-
-            @Override
             public void start()
             {
                 getProviders().forEach(p -> {
                     log.info(String.format("Starting background service %s", p.getName()));
                 });
-            }
-
-            @Override
-            public void stop()
-            {
-
-            }
-
-            @Override
-            public void teardown()
-            {
-
             }
         });
     }

--- a/service-framework-core/src/test/java/com/daedafusion/sf/providers/impl/ApacheCommonsCodecProvider.java
+++ b/service-framework-core/src/test/java/com/daedafusion/sf/providers/impl/ApacheCommonsCodecProvider.java
@@ -35,6 +35,12 @@ public class ApacheCommonsCodecProvider extends AbstractProvider implements Base
             }
 
             @Override
+            public void postStart()
+            {
+                log.info("provider postStart");
+            }
+
+            @Override
             public void stop()
             {
                 log.info("provider stop");


### PR DESCRIPTION
Needed a lifecycle event after the framework has been marked as started.  Took advantage of java 8 default interface implementation to clean things up a bit.